### PR TITLE
Fix image loading, use `%pip`, fix opencv dependency, etc.

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -147,8 +147,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load `imgbeddings` so we can calculate embeddings\n",
-    "#ibed = imgbeddings()\n",
     "# read the image\n",
     "img = Image.open(\"solo-image.png\")\n",
     "# calculating the embedding for that face\n",
@@ -179,13 +177,6 @@
     "cur.close()"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
  ],
  "metadata": {
   "kernelspec": {

--- a/main.ipynb
+++ b/main.ipynb
@@ -176,7 +176,7 @@
     "    display(Image(filename=\"stored-faces/\"+row[0]))\n",
     "cur.close()"
    ]
-  },
+  }
  ],
  "metadata": {
   "kernelspec": {

--- a/main.ipynb
+++ b/main.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -r requirements.txt"
+    "%pip install -r requirements.txt"
    ]
   },
   {
@@ -44,31 +44,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# importing the cv2 library\n",
+    "import os\n",
+    "# import the OpenCV library - it's called cv2\n",
     "import cv2\n",
     "\n",
-    "# loading the haar case algorithm file into alg variable\n",
-    "alg = \"haarcascade_frontalface_default.xml\"\n",
-    "# passing the algorithm to OpenCV\n",
-    "haar_cascade = cv2.CascadeClassifier(alg)\n",
-    "# loading the image path into file_name variable - replace <INSERT YOUR IMAGE NAME HERE> with the path to your image\n",
-    "file_name = \"test-image.png\"\n",
-    "# reading the image\n",
-    "img = cv2.imread(file_name, 0)\n",
-    "# creating a black and white version of the image\n",
-    "gray_img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)\n",
-    "# detecting the faces\n",
+    "# load the Haar Cascade algorithm from the XML file into OpenCV\n",
+    "haar_cascade = cv2.CascadeClassifier(\"haarcascade_frontalface_default.xml\")\n",
+    "\n",
+    "# read the test image as grayscale\n",
+    "gray_img = cv2.imread(\"test-image.png\", cv2.IMREAD_GRAYSCALE)\n",
+    "\n",
+    "# find the faces in that image\n",
+    "# this gives back an array of the x,y location of each face, and its width and height\n",
     "faces = haar_cascade.detectMultiScale(\n",
     "    gray_img, scaleFactor=1.05, minNeighbors=2, minSize=(100, 100)\n",
     ")\n",
     "\n",
+    "# make sure the directory we're going to write to actually exists\n",
+    "os.makedirs('stored-faces', exist_ok=True)\n",
+    "\n",
     "i = 0\n",
-    "# for each face detected\n",
+    "# write all the faces out to files\n",
+    "# for each face we found:\n",
     "for x, y, w, h in faces:\n",
     "    # crop the image to select only the face\n",
-    "    cropped_image = img[y : y + h, x : x + w]\n",
-    "    # loading the target image path into target_file_name variable  - replace <INSERT YOUR TARGET IMAGE NAME HERE> with the path to your target image\n",
-    "    target_file_name = 'stored-faces/' + str(i) + '.jpg'\n",
+    "    cropped_image = gray_img[y : y + h, x : x + w]\n",
+    "    # make up a filename for that face - we're just going to number them\n",
+    "    target_file_name = f'stored-faces/{i}.jpg'\n",
+    "    # report each file so we can tell we're doing something\n",
+    "    print(target_file_name)\n",
+    "    # and write the cropped face to the file\n",
     "    cv2.imwrite(\n",
     "        target_file_name,\n",
     "        cropped_image,\n",
@@ -82,7 +87,18 @@
    "source": [
     "## Step 2: Embeddings Calculation\n",
     "\n",
-    "Calculate embeddings from the faces and pushing to PostgreSQL, you'll need to change the `<SERVICE_URI>` parameter with the PostgreSQL Service URI"
+    "Calculate embeddings from the faces and pushing to PostgreSQL\n",
+    "\n",
+    "Remember you need to have enabled pgvector in PostgreSQL:\n",
+    "```sql\n",
+    "CREATE EXTENSION vector;\n",
+    "```\n",
+    "and created the table to write to\n",
+    "```sql\n",
+    "CREATE TABLE pictures (picture text PRIMARY KEY, embedding vector(768));\n",
+    "```\n",
+    "\n",
+    "In the following code, you'll need to change the `<SERVICE_URI>` string to the PostgreSQL Service URI"
    ]
   },
   {
@@ -91,25 +107,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# importing the required libraries\n",
+    "# import the other required libraries\n",
     "import numpy as np\n",
     "from imgbeddings import imgbeddings\n",
     "from PIL import Image\n",
     "import psycopg2\n",
-    "import os\n",
     "\n",
-    "# connecting to the database - replace the SERVICE URI with the service URI\n",
+    "# connect to the database - replace <SERVICE URI> with the actual service URI\n",
+    "# remember it needs to have the table defined already\n",
     "conn = psycopg2.connect(\"<SERVICE_URI>\")\n",
     "\n",
+    "# load `imgbeddings` so we can calculate embeddings\n",
+    "ibed = imgbeddings()\n",
+    "\n",
     "for filename in os.listdir(\"stored-faces\"):\n",
-    "    # opening the image\n",
+    "    # read the image\n",
     "    img = Image.open(\"stored-faces/\" + filename)\n",
-    "    # loading the `imgbeddings`\n",
-    "    ibed = imgbeddings()\n",
-    "    # calculating the embeddings\n",
-    "    embedding = ibed.to_embeddings(img)\n",
+    "    # calculate the embedding for this face\n",
+    "    embedding = ibed.to_embeddings(img)[0]\n",
+    "    # and write it to PostgreSQL\n",
     "    cur = conn.cursor()\n",
-    "    cur.execute(\"INSERT INTO pictures values (%s,%s)\", (filename, embedding[0].tolist()))\n",
+    "    cur.execute(\"INSERT INTO pictures values (%s,%s)\", (filename, embedding.tolist()))\n",
     "    print(filename)\n",
     "conn.commit()"
    ]
@@ -129,14 +147,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# loading the face image path into file_name variable\n",
-    "file_name = \"solo-image.png\"  # replace <INSERT YOUR FACE FILE NAME> with the path to your image\n",
-    "# opening the image\n",
-    "img = Image.open(file_name)\n",
-    "# loading the `imgbeddings`\n",
-    "ibed = imgbeddings()\n",
-    "# calculating the embeddings\n",
-    "embedding = ibed.to_embeddings(img)"
+    "# load `imgbeddings` so we can calculate embeddings\n",
+    "#ibed = imgbeddings()\n",
+    "# read the image\n",
+    "img = Image.open(\"solo-image.png\")\n",
+    "# calculating the embedding for that face\n",
+    "embedding = ibed.to_embeddings(img)[0]"
    ]
   },
   {
@@ -155,18 +171,25 @@
     "from IPython.display import Image, display\n",
     "\n",
     "cur = conn.cursor()\n",
-    "string_representation = \"[\"+ \",\".join(str(x) for x in embedding[0].tolist()) +\"]\"\n",
+    "string_representation = \"[\"+ \",\".join(str(x) for x in embedding.tolist()) +\"]\"\n",
     "cur.execute(\"SELECT * FROM pictures ORDER BY embedding <-> %s LIMIT 1;\", (string_representation,))\n",
     "rows = cur.fetchall()\n",
     "for row in rows:\n",
     "    display(Image(filename=\"stored-faces/\"+row[0]))\n",
     "cur.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -180,10 +203,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
-  },
-  "orig_nbformat": 4
+   "version": "3.11.3"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-opencv-python
+opencv-python-headless
 imgbeddings
 psycopg2-binary


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
**Note** this amended notebook runs locally on my machine, on GitHub Codespaces, and in GitPod

# About this change - What it does

* Use `%pip` instead of `!pip` to install requirements - this ensures that the notebook knows about them (`!pip` did not work for later cells when I ran the notebook locally)
* Change the requirement on `opencv-python` to `opencv-python-headless`. Otherwise, attempting to `import cv2` on Codespaces and in GitPod failed because it couldn't load `libGL.so.1`
* Correct the image loading to acknowledge it's already loading the image as grayscale (that's what the `0` argument means)
* Make sure the target `stored-files` directory is created - things tend to fail silently if it is not
* Give some simple feedback as files are written
* Remind the reader they need to have setup PostgreSQL correctly
* Always extract the `[0]` result from the embeddings array when first calculating it - this makes the name `embedding` more sensible, and save having to remember to do it each time `embedding` is used
* Update various comments, make some other minor code tidies

# Why this way

The main issue I wanted to fix was the incorrect comments around grayscale image loading.

The `%pip` issue was needed to enable me to test the notebook locally.

The "headless opencv" is presumably due to the versions of linux being run by the external services.

The other issues were mainly to improve readability

